### PR TITLE
2020-07-06 logrusScope.internal call panic策略

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # go-micro-ci-common
 基于Golang开发的微CI公共库
 
+## 2020-07-06 logrusScope.internal call panic策略
+1. 在call之前进行defer recover
+2. 上报panic的stack
+3. 将panic转换成error
+
 ## 2020-07-03 日志模块新增 v0.0.2-logs
 1. call 与 then 支持自定义函数调用
 2. 原 call 与 then 重构为 handle 与 thenHandle

--- a/tests/logrus_scope_test.go
+++ b/tests/logrus_scope_test.go
@@ -61,6 +61,9 @@ func TestLogrusScopeCall(t *testing.T) {
 		assert.Equal(t, "ThenError", err.Error())
 		return err
 	})
+
+	r = scope.Call(lc.CallPanic)
+	assert.Contains(t, r.GetError().Error(), "panic")
 }
 
 type logrusCall struct {
@@ -94,4 +97,9 @@ func (lc *logrusCall) ThenError() error {
 func (lc logrusCall) CallError(a string, ls *logs.LogrusScope, b string) (string, error) {
 	assert.NotNil(lc.T, ls)
 	return utils.EmptyString, fmt.Errorf(fmt.Sprintf("%s-%s", a, b))
+}
+
+func (lc logrusCall) CallPanic(ls *logs.LogrusScope) {
+	var a *logrusCall = nil
+	a.c = "aaa"
 }


### PR DESCRIPTION
1. 在call之前进行defer recover
2. 上报panic的stack
3. 将panic转换成error