### PR TITLE
2020-07-10 logrusScope 新增 catch 方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # go-micro-ci-common
 基于Golang开发的微CI公共库
 
+## 2020-07-10 logrusScope 新增 catch 方法
+1. 可以在call与then这后调用catch
+2. 返回错误则会继续调用onError, 如返回空，继续then
+
 ## 2020-07-10 service 新增 disableCommonEnv
 1. 部署时，如disableCommonEnv:true时，容器启动不会使用commonEnv的定义
 2. 容器环境变量覆盖优先级 commonEnv(if not 如disableCommonEnv) < registryEnv < serviceEnv

--- a/logs/logrus_scope.go
+++ b/logs/logrus_scope.go
@@ -42,6 +42,19 @@ type LogrusScopeResult struct {
 	*logrus.Entry
 }
 
+func (r *LogrusScopeResult) Catch(h LogrusScopeErrorHandler) *LogrusScopeResult {
+	if !r.HasError() {
+		return r
+	}
+
+	err := h(r.err, &LogrusScope{Entry: r.Entry})
+	return &LogrusScopeResult{
+		err:    err,
+		result: nil,
+		Entry:  r.Entry,
+	}
+}
+
 func (r *LogrusScopeResult) ThenHandle(h LogrusScopeThenHandler) *LogrusScopeResult {
 	if r.HasError() {
 		return r


### PR DESCRIPTION
1. 可以在call与then这后调用catch
2. 返回错误则会继续调用onError, 如返回空，继续then